### PR TITLE
fix: harden TLS, sync_db race, mail parsing, CLI hygiene

### DIFF
--- a/mailbox-cli/packages/mailbox-cli/package.json
+++ b/mailbox-cli/packages/mailbox-cli/package.json
@@ -20,6 +20,9 @@
     "monitor"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=18.17"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/leeguooooo/Mailbox"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "license": "MIT",
+  "engines": {
+    "node": ">=18.17"
+  },
   "bin": {
     "mailbox-dev": "bin/mailbox.js"
   },

--- a/packages/cli/src/main.js
+++ b/packages/cli/src/main.js
@@ -7,7 +7,48 @@ const { accounts, email, imap, smtp, sync } = require("@mailbox/core");
 const { digest, monitor, inbox } = require("@mailbox/workflows");
 
 function _printTextNotImplemented(label) {
-  process.stdout.write(`${label} (text mode) is not implemented yet. Use --json.\n`);
+  // Goes to stderr so it never corrupts a JSON pipe consumer.
+  process.stderr.write(`${label} (text mode) is not implemented yet. Use --json.\n`);
+}
+
+const MAX_BODY_FILE_BYTES = Number(process.env.MAILBOX_MAX_BODY_FILE_BYTES || 10 * 1024 * 1024); // 10 MiB
+
+function _readBodyFile(bodyFilePath) {
+  const st = fs.statSync(bodyFilePath);
+  if (st.size > MAX_BODY_FILE_BYTES) {
+    throw new Error(`--body-file exceeds ${MAX_BODY_FILE_BYTES} bytes (size=${st.size})`);
+  }
+  return fs.readFileSync(bodyFilePath, "utf8");
+}
+
+// Cooperative shutdown for foreground daemons. SIGINT/SIGTERM flips the flag
+// and resolves any in-flight wait so the loop can finish its current pass
+// (e.g. mid-flush sqlite write) before exiting.
+function _createStopSignal() {
+  const state = { stopped: false, wakers: new Set() };
+  const trigger = () => {
+    state.stopped = true;
+    for (const w of state.wakers) {
+      try { w(); } catch { /* ignore */ }
+    }
+    state.wakers.clear();
+  };
+  process.once("SIGINT", trigger);
+  process.once("SIGTERM", trigger);
+  return {
+    stopped: () => state.stopped,
+    sleep(ms) {
+      if (state.stopped) return Promise.resolve();
+      return new Promise((resolve) => {
+        const t = setTimeout(() => {
+          state.wakers.delete(resolve);
+          resolve();
+        }, ms);
+        const wake = () => { clearTimeout(t); resolve(); };
+        state.wakers.add(wake);
+      });
+    },
+  };
 }
 
 function _resolveCliVersion() {
@@ -326,7 +367,7 @@ async function main(argv) {
       let body = opts.body || "";
       if (opts.bodyFile) {
         try {
-          body = require("fs").readFileSync(opts.bodyFile, "utf8");
+          body = _readBodyFile(opts.bodyFile);
         } catch (e) {
           const rc = contract.invalidUsage({ message: e && e.message ? e.message : "Failed to read body file", asJson, pretty });
           process.exit(rc);
@@ -366,7 +407,7 @@ async function main(argv) {
       let body = opts.body || "";
       if (opts.bodyFile) {
         try {
-          body = require("fs").readFileSync(opts.bodyFile, "utf8");
+          body = _readBodyFile(opts.bodyFile);
         } catch (e) {
           const rc = contract.invalidUsage({ message: e && e.message ? e.message : "Failed to read body file", asJson, pretty });
           process.exit(rc);
@@ -535,15 +576,16 @@ async function main(argv) {
     .action(async (opts) => {
       const { printJson } = require("@mailbox/shared").json;
       const intervalSec = Math.max(0.5, Number(opts.interval || 5));
+      const stop = _createStopSignal();
       try {
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
+        while (!stop.stopped()) {
           const status = sync.status();
           status.success = true;
           printJson(status, Boolean(pretty) || !asJson);
           // eslint-disable-next-line no-await-in-loop
-          await new Promise((r) => setTimeout(r, intervalSec * 1000));
+          await stop.sleep(intervalSec * 1000);
         }
+        return process.exit(0);
       } catch (e) {
         if (e && e.name === "AbortError") return process.exit(0);
         return process.exit(0);
@@ -558,14 +600,16 @@ async function main(argv) {
     .option("--full")
     .action(async (opts) => {
       const intervalSec = Math.max(5, Number(opts.interval || 300));
+      const stop = _createStopSignal();
       try {
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
+        while (!stop.stopped()) {
           // eslint-disable-next-line no-await-in-loop
           await sync.force({ account_id: opts.accountId || "", full: Boolean(opts.full) });
+          if (stop.stopped()) break;
           // eslint-disable-next-line no-await-in-loop
-          await new Promise((r) => setTimeout(r, intervalSec * 1000));
+          await stop.sleep(intervalSec * 1000);
         }
+        return process.exit(0);
       } catch {
         return process.exit(0);
       }
@@ -599,14 +643,16 @@ async function main(argv) {
     .option("--dry-run")
     .action(async (opts) => {
       const intervalSec = Math.max(5, Number(opts.interval || 3600));
+      const stop = _createStopSignal();
       try {
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
+        while (!stop.stopped()) {
           // eslint-disable-next-line no-await-in-loop
           await digest.run({ dry_run: Boolean(opts.dryRun), debug_path: "" });
+          if (stop.stopped()) break;
           // eslint-disable-next-line no-await-in-loop
-          await new Promise((r) => setTimeout(r, intervalSec * 1000));
+          await stop.sleep(intervalSec * 1000);
         }
+        return process.exit(0);
       } catch {
         return process.exit(0);
       }

--- a/packages/cli/test/_helpers.mjs
+++ b/packages/cli/test/_helpers.mjs
@@ -21,7 +21,7 @@ export function writeAuthJson(configDir, auth) {
 export function testEnv(tmpRoot) {
   return {
     ...process.env,
-    MAILBOX_TEST_MODE: "1",
+    MAILBOX_INTERNAL_TEST_MODE: "1",
     MAILBOX_CONFIG_DIR: path.join(tmpRoot, "config"),
     MAILBOX_DATA_DIR: path.join(tmpRoot, "data"),
   };

--- a/packages/core/src/services/email.js
+++ b/packages/core/src/services/email.js
@@ -9,7 +9,24 @@ const { sendMail } = require("./smtp");
 const { formatDateTime, firstAddress, hasAttachmentsFromBodyStructure, formatSize } = require("./format");
 
 function _isTestMode() {
-  return String(process.env.MAILBOX_TEST_MODE || "").trim() === "1";
+  // Internal sentinel only — kept narrowly named to avoid colliding with any
+  // env a user might set. Tests must opt in explicitly.
+  return String(process.env.MAILBOX_INTERNAL_TEST_MODE || "").trim() === "1";
+}
+
+// Hard caps to defend against hostile mail. Override via env if needed.
+const MAX_MESSAGE_BYTES = Number(process.env.MAILBOX_MAX_MESSAGE_BYTES || 50 * 1024 * 1024); // 50 MiB
+const MAX_ATTACHMENT_BYTES = Number(process.env.MAILBOX_MAX_ATTACHMENT_BYTES || 25 * 1024 * 1024); // 25 MiB per file
+const MAX_ATTACHMENTS_TOTAL = Number(process.env.MAILBOX_MAX_ATTACHMENTS_BYTES || 100 * 1024 * 1024); // 100 MiB total
+
+async function _safeParse(source) {
+  if (source && Buffer.isBuffer(source) && source.length > MAX_MESSAGE_BYTES) {
+    throw new Error(`Message exceeds MAILBOX_MAX_MESSAGE_BYTES (${MAX_MESSAGE_BYTES})`);
+  }
+  const { simpleParser } = require("mailparser");
+  return simpleParser(source, {
+    maxHtmlLengthToParse: MAX_MESSAGE_BYTES,
+  });
 }
 
 function _normalizeFolder(folder) {
@@ -21,6 +38,19 @@ function _normalizeFolder(folder) {
 
 function _uidsSortedDesc(uids) {
   return [...uids].map((n) => Number(n)).filter((n) => Number.isFinite(n)).sort((a, b) => b - a);
+}
+
+// Compare email date strings as instants, not lex strings. Falls back to lex
+// only when both dates are unparseable, so we still get stable ordering.
+function _compareDatesDesc(a, b) {
+  const av = a ? Date.parse(String(a).replace(" ", "T")) : NaN;
+  const bv = b ? Date.parse(String(b).replace(" ", "T")) : NaN;
+  const aOk = Number.isFinite(av);
+  const bOk = Number.isFinite(bv);
+  if (aOk && bOk) return bv - av;
+  if (aOk) return -1;
+  if (bOk) return 1;
+  return String(b || "").localeCompare(String(a || ""));
 }
 
 function _dateOnly(raw) {
@@ -151,8 +181,10 @@ async function listEmails({
           accounts_info: [],
         };
       }
-    } catch {
-      // ignore
+    } catch (e) {
+      // Cache failed → fall through to live IMAP. Surface the reason so users
+      // can tell why use_cache=true didn't actually use the cache.
+      process.stderr.write(`mailbox: cache read failed, falling back to live IMAP: ${e && e.message ? e.message : e}\n`);
     }
   }
 
@@ -206,7 +238,7 @@ async function listEmails({
 
   const ok = results.filter((r) => r.success);
   const allEmails = ok.flatMap((r) => r.emails || []);
-  allEmails.sort((a, b) => String(b.date || "").localeCompare(String(a.date || "")));
+  allEmails.sort((a, b) => _compareDatesDesc(a.date, b.date));
   const emails = lim > 0 ? allEmails.slice(off, off + lim) : [];
 
   const returnedByAccount = new Map();
@@ -346,7 +378,7 @@ async function searchEmails({ query, account_id = "", date_from = "", date_to = 
   }
 
   const allEmails = perAccount.flatMap((r) => (r && r.success ? r.emails || [] : []));
-  allEmails.sort((a, b) => String(b.date || "").localeCompare(String(a.date || "")));
+  allEmails.sort((a, b) => _compareDatesDesc(a.date, b.date));
 
   const page = allEmails.slice(off, off + lim);
   const total_found = perAccount.reduce((sum, r) => sum + Number((r && r.total_found) || 0), 0);
@@ -468,8 +500,7 @@ async function showEmail({
       };
     }
 
-    const { simpleParser } = require("mailparser");
-    const parsed = await simpleParser(msg.source);
+    const parsed = await _safeParse(msg.source);
     const flags = msg.flags || new Set([]);
     const unread = !flags.has("\\Seen");
 
@@ -582,21 +613,37 @@ async function markEmails({ email_ids, mark_as, folder = "INBOX", account_id = "
 
 async function _findTrashFolder(client, preferredName) {
   const pref = String(preferredName || "").trim();
-  let fallback = pref || "Trash";
   const listResult = await client.list();
   const iterate = listResult && typeof listResult[Symbol.asyncIterator] === "function"
     ? listResult
     : Array.isArray(listResult)
       ? listResult
       : [];
+
+  let exactMatch = "";
+  let bySpecialUse = "";
   for await (const mb of iterate) {
     const pathName = mb.path || mb.name || "";
+    if (!pathName) continue;
     const special = String(mb.specialUse || "");
-    if (special && special.toLowerCase().includes("trash")) return pathName;
-    if (pathName.toLowerCase() === "trash") return pathName;
-    if (pathName.toLowerCase() === "deleted items") fallback = pathName;
+    if (special === "\\Trash") {
+      bySpecialUse = pathName;
+      // \Trash is authoritative; stop searching as soon as we find it.
+      break;
+    }
+    if (pref && pathName === pref) exactMatch = pathName;
   }
-  return fallback;
+
+  if (bySpecialUse) return bySpecialUse;
+  if (exactMatch) return exactMatch;
+  // No \Trash special-use and no exact preferred-name match: fail loudly so
+  // we don't silently fall through to a non-existent "Trash" folder, which
+  // would error out per UID inside messageMove anyway.
+  throw new Error(
+    pref
+      ? `Trash folder not found: server has no \\Trash special-use mailbox and "${pref}" does not exist. Pass --trash-folder <name> or use --permanent.`
+      : "Trash folder not found: server has no \\Trash special-use mailbox. Pass --trash-folder <name> or use --permanent."
+  );
 }
 
 async function deleteEmails({ email_ids, folder = "INBOX", permanent = false, trash_folder = "Trash", account_id = "", dry_run = false } = {}) {
@@ -624,7 +671,13 @@ async function deleteEmails({ email_ids, folder = "INBOX", permanent = false, tr
     const results = [];
 
     let trashName = "";
-    if (!permanent) trashName = await _findTrashFolder(client, trash_folder);
+    if (!permanent) {
+      try {
+        trashName = await _findTrashFolder(client, trash_folder);
+      } catch (e) {
+        return { success: false, error: e && e.message ? e.message : "Trash folder lookup failed" };
+      }
+    }
 
     for (const uid of uids) {
       try {
@@ -778,19 +831,39 @@ async function forwardEmail({ email_id, to, body = "", folder = "INBOX", no_atta
 
   let attachments = [];
   if (!no_attachments && detail.attachment_count) {
-    // Best-effort: re-parse the email source to get attachment content when possible.
     if (_isTestMode()) {
       const { getMailbox } = require("../testing/mock_store");
       const mb = getMailbox(acc.account.id, _normalizeFolder(folder));
       const raw = mb && mb.messages ? mb.messages.find((m) => String(m.uid) === String(email_id)) : null;
       attachments = (raw && raw.attachments ? raw.attachments : []).map((a) => ({
-        filename: a.filename,
+        filename: path.basename(String(a.filename || "attachment")),
         content: a.content,
         contentType: a.contentType,
       }));
     } else {
-      // Fall back to forwarding without attachments.
-      attachments = [];
+      // Re-fetch the source so we can attach the original parts. Without this
+      // --no-attachments would be a no-op vs. always-drop, which is misleading.
+      const fetched = await withImapClient(acc.account, async (client) => {
+        await client.mailboxOpen(_normalizeFolder(folder));
+        const uid = Number(email_id);
+        if (!Number.isFinite(uid)) return null;
+        return client.fetchOne(uid, { source: true }, { uid: true });
+      });
+      if (fetched && fetched.source) {
+        const parsed = await _safeParse(fetched.source);
+        let totalBytes = 0;
+        for (const a of parsed.attachments || []) {
+          if (!a.content || !a.content.length) continue;
+          if (a.content.length > MAX_ATTACHMENT_BYTES) continue;
+          totalBytes += a.content.length;
+          if (totalBytes > MAX_ATTACHMENTS_TOTAL) break;
+          attachments.push({
+            filename: path.basename(String(a.filename || "attachment")),
+            content: a.content,
+            contentType: a.contentType || "application/octet-stream",
+          });
+        }
+      }
     }
   }
 
@@ -845,6 +918,22 @@ async function downloadAttachments({ email_id, folder = "INBOX", account_id, out
   const targetDir = output_dir ? String(output_dir) : paths.getPathConfig().attachmentsDir;
   fs.mkdirSync(targetDir, { recursive: true });
 
+  // Pick a non-conflicting filename inside targetDir, basename-only to defeat
+  // path traversal from attacker-supplied filenames.
+  const _pickDest = (rawName) => {
+    const filename = path.basename(String(rawName || "attachment"));
+    if (!filename) return { filename: "", dest: "" };
+    let dest = path.join(targetDir, filename);
+    const ext = path.extname(filename);
+    const base = ext ? filename.slice(0, -ext.length) : filename;
+    let counter = 1;
+    while (fs.existsSync(dest)) {
+      dest = path.join(targetDir, `${base}_${counter}${ext}`);
+      counter += 1;
+    }
+    return { filename, dest };
+  };
+
   if (_isTestMode()) {
     const acc = accounts.getAccountByIdOrEmail(account_id);
     if (!acc.success) return acc;
@@ -852,15 +941,26 @@ async function downloadAttachments({ email_id, folder = "INBOX", account_id, out
     const mb = getMailbox(acc.account.id, _normalizeFolder(folder));
     const raw = mb && mb.messages ? mb.messages.find((m) => String(m.uid) === String(email_id)) : null;
     const attachments = [];
+    let totalBytes = 0;
     for (const a of raw && raw.attachments ? raw.attachments : []) {
-      const p = path.join(targetDir, a.filename);
-      fs.writeFileSync(p, a.content);
+      const content = a.content;
+      if (!content || !content.length) continue;
+      if (content.length > MAX_ATTACHMENT_BYTES) {
+        return { success: false, error: `Attachment "${a.filename}" exceeds ${MAX_ATTACHMENT_BYTES} bytes` };
+      }
+      totalBytes += content.length;
+      if (totalBytes > MAX_ATTACHMENTS_TOTAL) {
+        return { success: false, error: `Attachments exceed total cap of ${MAX_ATTACHMENTS_TOTAL} bytes` };
+      }
+      const { filename, dest } = _pickDest(a.filename);
+      if (!filename) continue;
+      fs.writeFileSync(dest, content);
       attachments.push({
-        filename: a.filename,
-        size: a.content.length,
-        size_formatted: formatSize(a.content.length),
+        filename,
+        size: content.length,
+        size_formatted: formatSize(content.length),
         content_type: a.contentType,
-        saved_path: p,
+        saved_path: dest,
       });
     }
     return {
@@ -885,25 +985,22 @@ async function downloadAttachments({ email_id, folder = "INBOX", account_id, out
     const msg = await client.fetchOne(uid, { source: true, envelope: true }, { uid: true });
     if (!msg || !msg.source) return { success: false, error: `Email not found: ${email_id}` };
 
-    const { simpleParser } = require("mailparser");
-    const parsed = await simpleParser(msg.source);
+    const parsed = await _safeParse(msg.source);
 
     const attachments = [];
+    let totalBytes = 0;
     for (const a of parsed.attachments || []) {
-      const filenameRaw = a.filename || "attachment";
-      const filename = path.basename(String(filenameRaw));
-      if (!filename) continue;
       const content = a.content;
       if (!content || !content.length) continue;
-
-      let dest = path.join(targetDir, filename);
-      const ext = path.extname(filename);
-      const base = ext ? filename.slice(0, -ext.length) : filename;
-      let counter = 1;
-      while (fs.existsSync(dest)) {
-        dest = path.join(targetDir, `${base}_${counter}${ext}`);
-        counter += 1;
+      if (content.length > MAX_ATTACHMENT_BYTES) {
+        return { success: false, error: `Attachment "${a.filename || "(unnamed)"}" exceeds ${MAX_ATTACHMENT_BYTES} bytes` };
       }
+      totalBytes += content.length;
+      if (totalBytes > MAX_ATTACHMENTS_TOTAL) {
+        return { success: false, error: `Attachments exceed total cap of ${MAX_ATTACHMENTS_TOTAL} bytes` };
+      }
+      const { filename, dest } = _pickDest(a.filename);
+      if (!filename) continue;
       fs.writeFileSync(dest, content);
 
       attachments.push({

--- a/packages/core/src/services/email.js
+++ b/packages/core/src/services/email.js
@@ -455,6 +455,8 @@ async function showEmail({
         attachment_count: attachments.length,
         unread,
         message_id: raw.messageId || "",
+        in_reply_to: raw.inReplyTo || "",
+        references: raw.references || "",
         folder: openFolder,
         account: acc.account.email,
         account_id: acc.account.id,
@@ -515,6 +517,10 @@ async function showEmail({
       attachment_count: attachments.length,
       unread,
       message_id: parsed.messageId || (msg.envelope ? msg.envelope.messageId : ""),
+      in_reply_to: parsed.inReplyTo || "",
+      references: Array.isArray(parsed.references)
+        ? parsed.references.join(" ")
+        : (parsed.references || ""),
       folder: openFolder,
       account: acc.account.email,
       account_id: acc.account.id,
@@ -674,30 +680,86 @@ async function sendEmail({ to, subject, body, cc, bcc, account_id = "", is_html 
   }
 }
 
+// Common reply-prefix forms across locales. Matches "Re:", "RE：", "回复:",
+// "答复:", "Sv:", "Antwort:", "AW:", "RES:", "Tr:" with optional whitespace.
+const _REPLY_PREFIX_RE = /^\s*(re|aw|antwort|sv|res|回复|答复|回覆|tr)\s*[:：]/i;
+
+function _splitAddressList(value) {
+  if (!value) return [];
+  return String(value)
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function _addressEmail(addr) {
+  const m = String(addr).match(/<([^>]+)>/);
+  return (m ? m[1] : String(addr)).trim().toLowerCase();
+}
+
+function _dedupeAddresses(list, exclude) {
+  const excluded = new Set((exclude || []).map((x) => String(x).toLowerCase()));
+  const seen = new Set();
+  const out = [];
+  for (const addr of list) {
+    const key = _addressEmail(addr);
+    if (!key || excluded.has(key) || seen.has(key)) continue;
+    seen.add(key);
+    out.push(addr);
+  }
+  return out;
+}
+
+function _buildReferences(detail) {
+  const refs = [];
+  const existing = detail.references ? String(detail.references).trim() : "";
+  if (existing) refs.push(existing);
+  const parent = detail.message_id ? String(detail.message_id).trim() : "";
+  if (parent && !refs.join(" ").includes(parent)) refs.push(parent);
+  return refs.join(" ").trim();
+}
+
 async function replyEmail({ email_id, body, reply_all = false, folder = "INBOX", account_id = "", is_html = false } = {}) {
   const detail = await showEmail({ email_id, folder, account_id });
   if (!detail.success) return detail;
   const acc = accounts.getAccountByIdOrEmail(account_id);
   if (!acc.success) return acc;
 
-  const to = reply_all ? detail.to : detail.from;
-  const subject = detail.subject && detail.subject.toLowerCase().startsWith("re:") ? detail.subject : `Re: ${detail.subject || ""}`;
+  const fromAddr = detail.from || "";
+  let toList = [fromAddr].filter(Boolean);
+  let ccList = [];
+  if (reply_all) {
+    const origTo = _splitAddressList(detail.to);
+    const origCc = _splitAddressList(detail.cc);
+    toList = _dedupeAddresses([fromAddr, ...origTo], [acc.account.email]);
+    ccList = _dedupeAddresses(origCc, [acc.account.email, ..._dedupeAddresses(toList).map(_addressEmail)]);
+  }
+  if (!toList.length) {
+    return { success: false, error: "Reply has no recipient (original sender unknown)", from: acc.account.email };
+  }
+
+  const subjectRaw = detail.subject || "";
+  const subject = _REPLY_PREFIX_RE.test(subjectRaw) ? subjectRaw : `Re: ${subjectRaw}`;
+  const headers = {};
+  if (detail.message_id) headers["In-Reply-To"] = detail.message_id;
+  const refs = _buildReferences(detail);
+  if (refs) headers.References = refs;
+
   try {
     await sendMail({
       account: acc.account,
-      to,
+      to: toList.join(", "),
+      cc: ccList.length ? ccList.join(", ") : undefined,
       subject,
       text: is_html ? "" : String(body || ""),
       html: is_html ? String(body || "") : "",
-      headers: {
-        "In-Reply-To": detail.message_id || "",
-        References: detail.message_id || "",
-      },
+      headers,
     });
     return {
       success: true,
       message: "Reply sent successfully",
-      recipients: [to],
+      recipients: toList,
+      cc: ccList,
       from: acc.account.email,
     };
   } catch (e) {
@@ -864,6 +926,23 @@ async function downloadAttachments({ email_id, folder = "INBOX", account_id, out
   });
 }
 
+// Map user-facing flag_type to IMAP keyword. Unknown values fall through as
+// custom keywords (which any IMAP server may accept or reject) so we don't
+// silently coerce them into \Flagged.
+const _FLAG_MAP = {
+  flagged: "\\Flagged",
+  starred: "\\Flagged",
+  important: "$Important",
+  read: "\\Seen",
+  seen: "\\Seen",
+  answered: "\\Answered",
+  draft: "\\Draft",
+  junk: "$Junk",
+  spam: "$Junk",
+  notjunk: "$NotJunk",
+  forwarded: "$Forwarded",
+};
+
 async function flagEmail({ email_id, set_flag, flag_type = "flagged", folder = "INBOX", account_id } = {}) {
   const acc = accounts.getAccountByIdOrEmail(account_id);
   if (!acc.success) return acc;
@@ -872,7 +951,7 @@ async function flagEmail({ email_id, set_flag, flag_type = "flagged", folder = "
   if (!Number.isFinite(uid)) return { success: false, error: "Invalid email_id" };
 
   const flagType = String(flag_type || "flagged").toLowerCase();
-  const flag = flagType === "flagged" ? "\\Flagged" : "\\Flagged";
+  const flag = _FLAG_MAP[flagType] || flagType;
   const set = Boolean(set_flag);
 
   return withImapClient(acc.account, async (client) => {

--- a/packages/core/src/services/imap.js
+++ b/packages/core/src/services/imap.js
@@ -1,5 +1,5 @@
 function _isTestMode() {
-  return String(process.env.MAILBOX_TEST_MODE || "").trim() === "1";
+  return String(process.env.MAILBOX_INTERNAL_TEST_MODE || "").trim() === "1";
 }
 
 function _allowInsecureTls() {

--- a/packages/core/src/services/imap.js
+++ b/packages/core/src/services/imap.js
@@ -2,6 +2,10 @@ function _isTestMode() {
   return String(process.env.MAILBOX_TEST_MODE || "").trim() === "1";
 }
 
+function _allowInsecureTls() {
+  return String(process.env.MAILBOX_ALLOW_INSECURE_TLS || "").trim() === "1";
+}
+
 async function withImapClient(account, fn) {
   if (_isTestMode()) {
     const { createMockImapClient } = require("../testing/mock_imap_client");
@@ -10,14 +14,23 @@ async function withImapClient(account, fn) {
   }
 
   const { ImapFlow } = require("imapflow");
+  const port = Number(account.imap.port);
+  const secure = Boolean(account.imap.secure);
+  const tls = {
+    rejectUnauthorized: !_allowInsecureTls(),
+    minVersion: "TLSv1.2",
+  };
+  // Implicit TLS (993): connect over TLS. Otherwise require STARTTLS to refuse plaintext.
   const client = new ImapFlow({
     host: account.imap.host,
-    port: account.imap.port,
-    secure: Boolean(account.imap.secure),
+    port,
+    secure,
+    requireTLS: !secure,
     auth: {
       user: account.email,
       pass: account.password,
     },
+    tls,
     logger: false,
   });
 

--- a/packages/core/src/services/smtp.js
+++ b/packages/core/src/services/smtp.js
@@ -1,5 +1,5 @@
 function _isTestMode() {
-  return String(process.env.MAILBOX_TEST_MODE || "").trim() === "1";
+  return String(process.env.MAILBOX_INTERNAL_TEST_MODE || "").trim() === "1";
 }
 
 function _allowInsecureTls() {

--- a/packages/core/src/services/smtp.js
+++ b/packages/core/src/services/smtp.js
@@ -2,6 +2,34 @@ function _isTestMode() {
   return String(process.env.MAILBOX_TEST_MODE || "").trim() === "1";
 }
 
+function _allowInsecureTls() {
+  return String(process.env.MAILBOX_ALLOW_INSECURE_TLS || "").trim() === "1";
+}
+
+function _buildTransportOptions(account) {
+  const port = Number(account.smtp.port);
+  const secure = Boolean(account.smtp.secure);
+  const opts = {
+    host: account.smtp.host,
+    port,
+    secure,
+    auth: {
+      user: account.email,
+      pass: account.password,
+    },
+    tls: {
+      rejectUnauthorized: !_allowInsecureTls(),
+      minVersion: "TLSv1.2",
+    },
+  };
+  // Implicit TLS (465): no STARTTLS upgrade. For everything else (587, 25, custom),
+  // require STARTTLS so a hostile MITM can't strip TLS and force plaintext auth.
+  if (!secure) {
+    opts.requireTLS = true;
+  }
+  return opts;
+}
+
 async function testConnection(account) {
   if (_isTestMode()) {
     return { success: true };
@@ -12,15 +40,7 @@ async function testConnection(account) {
   }
 
   const nodemailer = require("nodemailer");
-  const transporter = nodemailer.createTransport({
-    host: account.smtp.host,
-    port: account.smtp.port,
-    secure: Boolean(account.smtp.secure),
-    auth: {
-      user: account.email,
-      pass: account.password,
-    },
-  });
+  const transporter = nodemailer.createTransport(_buildTransportOptions(account));
 
   try {
     await transporter.verify();
@@ -39,15 +59,7 @@ async function sendMail({ account, to, cc, bcc, subject, text, html, attachments
   }
 
   const nodemailer = require("nodemailer");
-  const transporter = nodemailer.createTransport({
-    host: account.smtp.host,
-    port: account.smtp.port,
-    secure: Boolean(account.smtp.secure),
-    auth: {
-      user: account.email,
-      pass: account.password,
-    },
-  });
+  const transporter = nodemailer.createTransport(_buildTransportOptions(account));
 
   const info = await transporter.sendMail({
     from: account.email,

--- a/packages/core/src/services/sync.js
+++ b/packages/core/src/services/sync.js
@@ -70,12 +70,10 @@ function status() {
 
 async function force({ account_id = "", full = false } = {}) {
   const pc = paths.getPathConfig();
-  // Ensure sqlite schema exists and is writable.
+  // Ensure parent dir exists. Don't pre-create a 0-byte file: sql.js treats
+  // an empty Uint8Array as a corrupt DB. The first write session creates it.
   try {
-    if (!fs.existsSync(pc.emailSyncDb)) {
-      fs.mkdirSync(require("path").dirname(pc.emailSyncDb), { recursive: true });
-      fs.writeFileSync(pc.emailSyncDb, Buffer.from([]));
-    }
+    fs.mkdirSync(require("path").dirname(pc.emailSyncDb), { recursive: true });
   } catch {
     // ignore
   }
@@ -98,23 +96,24 @@ async function force({ account_id = "", full = false } = {}) {
       // eslint-disable-next-line no-await-in-loop
       const listRes = await email.listEmails({ limit: 200, offset: 0, unread_only: false, folder: "INBOX", account_id: a.id, use_cache: false });
 
-      // Update cache DB for this account+folder.
+      // Single write session per account: one DB open, one flush, one file
+      // lock. Prevents lost updates across concurrent CLI invocations and
+      // the within-account upsertAccount → upsertFolder → upsertEmails race.
       // eslint-disable-next-line no-await-in-loop
-      await syncDb.upsertAccount({ dbPath: pc.emailSyncDb, id: a.id, email: a.email, provider: a.provider || "custom" });
-      // eslint-disable-next-line no-await-in-loop
-      const folderRes = await syncDb.upsertFolder({
-        dbPath: pc.emailSyncDb,
-        accountId: a.id,
-        name: "INBOX",
-        displayName: "INBOX",
-        messageCount: listRes.total_in_folder || 0,
-        unreadCount: listRes.unread_count || 0,
-        lastSyncIso: _nowIso(),
+      await syncDb.withWriteSession(pc.emailSyncDb, (s) => {
+        s.upsertAccount({ id: a.id, email: a.email, provider: a.provider || "custom" });
+        const folderId = s.upsertFolder({
+          accountId: a.id,
+          name: "INBOX",
+          displayName: "INBOX",
+          messageCount: listRes.total_in_folder || 0,
+          unreadCount: listRes.unread_count || 0,
+          lastSyncIso: _nowIso(),
+        });
+        if (folderId) {
+          s.upsertEmails({ accountId: a.id, folderId, emails: listRes.emails || [] });
+        }
       });
-      if (folderRes && folderRes.success) {
-        // eslint-disable-next-line no-await-in-loop
-        await syncDb.upsertEmails({ dbPath: pc.emailSyncDb, accountId: a.id, folderId: folderRes.folderId, emails: listRes.emails || [] });
-      }
 
       const per = {
         last_sync: _nowIso(),

--- a/packages/core/src/storage/sync_db.js
+++ b/packages/core/src/storage/sync_db.js
@@ -15,15 +15,52 @@ function _readDbFile(dbPath) {
   try {
     if (!fs.existsSync(dbPath)) return null;
     const buf = fs.readFileSync(dbPath);
+    if (!buf || buf.length === 0) return null;
     return new Uint8Array(buf);
   } catch {
     return null;
   }
 }
 
-function _writeDbFile(dbPath, bytes) {
+function _writeDbFileAtomic(dbPath, bytes) {
   fs.mkdirSync(path.dirname(dbPath), { recursive: true });
-  fs.writeFileSync(dbPath, Buffer.from(bytes));
+  const tmp = `${dbPath}.tmp.${process.pid}.${Date.now()}`;
+  fs.writeFileSync(tmp, Buffer.from(bytes));
+  fs.renameSync(tmp, dbPath);
+}
+
+async function _acquireLock(dbPath, { retries = 100, delayMs = 50 } = {}) {
+  const lockPath = `${dbPath}.lock`;
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+  for (let i = 0; i < retries; i += 1) {
+    try {
+      const fd = fs.openSync(lockPath, "wx");
+      try {
+        fs.writeSync(fd, String(process.pid));
+      } finally {
+        fs.closeSync(fd);
+      }
+      return lockPath;
+    } catch (e) {
+      if (e && e.code !== "EEXIST") throw e;
+      // Stale lock: if older than 60s, remove it.
+      try {
+        const st = fs.statSync(lockPath);
+        if (Date.now() - st.mtimeMs > 60_000) {
+          try { fs.unlinkSync(lockPath); } catch { /* ignore */ }
+          continue;
+        }
+      } catch { /* lock disappeared, retry */ }
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  throw new Error(`sync_db: could not acquire lock at ${lockPath}`);
+}
+
+function _releaseLock(lockPath) {
+  if (!lockPath) return;
+  try { fs.unlinkSync(lockPath); } catch { /* ignore */ }
 }
 
 function _ensureSchema(db) {
@@ -175,6 +212,7 @@ function _execRows(db, sql, params) {
   }
 }
 
+// Open the DB without an exclusive lock — readers only. Call close() when done.
 async function openSyncDb(dbPath) {
   const SQL = await _getSQL();
   const data = _readDbFile(dbPath);
@@ -184,12 +222,101 @@ async function openSyncDb(dbPath) {
     db,
     flush() {
       const bytes = db.export();
-      _writeDbFile(dbPath, bytes);
+      _writeDbFileAtomic(dbPath, bytes);
     },
     close() {
       db.close();
     },
   };
+}
+
+// Run a write session under an exclusive file lock. Opens the DB once,
+// allows the caller to issue many writes through `session`, then flushes
+// once on success. Releases the lock on all exit paths.
+async function withWriteSession(dbPath, fn) {
+  const lockPath = await _acquireLock(dbPath);
+  let h;
+  try {
+    h = await openSyncDb(dbPath);
+    const session = {
+      db: h.db,
+      upsertAccount({ id, email, provider }) {
+        h.db.run(
+          "INSERT OR REPLACE INTO accounts (id, email, provider, updated_at) VALUES (?, ?, ?, CURRENT_TIMESTAMP)",
+          [String(id), String(email), String(provider)]
+        );
+      },
+      upsertFolder({ accountId, name, displayName, messageCount, unreadCount, lastSyncIso }) {
+        h.db.run(
+          `
+            INSERT INTO folders (account_id, name, display_name, message_count, unread_count, last_sync)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(account_id, name) DO UPDATE SET
+              display_name = excluded.display_name,
+              message_count = excluded.message_count,
+              unread_count = excluded.unread_count,
+              last_sync = excluded.last_sync
+          `,
+          [
+            String(accountId),
+            String(name),
+            String(displayName || name),
+            Number(messageCount || 0),
+            Number(unreadCount || 0),
+            String(lastSyncIso || new Date().toISOString()),
+          ]
+        );
+        return Number(_execScalar(
+          h.db,
+          "SELECT id FROM folders WHERE account_id = ? AND name = ?",
+          [String(accountId), String(name)]
+        ));
+      },
+      upsertEmails({ accountId, folderId, emails }) {
+        const stmt = h.db.prepare(
+          `
+            INSERT OR REPLACE INTO emails (
+              account_id, folder_id, uid, message_id, subject, sender, sender_email, recipients,
+              date_sent, is_read, is_flagged, is_deleted, has_attachments, size_bytes, sync_status, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'synced', CURRENT_TIMESTAMP)
+          `
+        );
+        try {
+          for (const e of emails || []) {
+            const uid = String(e.uid || e.id || "").trim();
+            if (!uid) continue;
+            const isRead = e.unread ? 0 : 1;
+            stmt.run([
+              String(accountId),
+              Number(folderId),
+              uid,
+              String(e.message_id || ""),
+              String(e.subject || ""),
+              String(e.from || ""),
+              String(e.from || ""),
+              JSON.stringify({ to: e.to || "", cc: e.cc || "" }),
+              String(e.date || ""),
+              isRead,
+              0,
+              0,
+              e.has_attachments ? 1 : 0,
+              Number(e.size_bytes || e.size || 0),
+            ]);
+          }
+        } finally {
+          stmt.free();
+        }
+      },
+    };
+    const result = await fn(session);
+    h.flush();
+    return result;
+  } finally {
+    if (h) {
+      try { h.close(); } catch { /* ignore */ }
+    }
+    _releaseLock(lockPath);
+  }
 }
 
 async function listEmailsFromCache({ dbPath, accountId, folder, unreadOnly, limit, offset, dateFrom, dateTo }) {
@@ -219,37 +346,37 @@ async function listEmailsFromCache({ dbPath, accountId, folder, unreadOnly, limi
       WHERE e.is_deleted = 0
     `;
 
-    const params = [];
+    const filterParams = [];
     if (accountId) {
       query += " AND e.account_id = ?";
-      params.push(String(accountId));
+      filterParams.push(String(accountId));
     }
     if (resolvedFolder !== "all") {
       query += " AND (f.name = ? COLLATE NOCASE OR (e.folder_id IS NULL AND ? = 'INBOX'))";
-      params.push(resolvedFolder);
-      params.push(resolvedFolder);
+      filterParams.push(resolvedFolder);
+      filterParams.push(resolvedFolder);
     }
     if (unreadOnly) {
       query += " AND e.is_read = 0";
     }
     if (dateFrom) {
       query += " AND e.date_sent >= ?";
-      params.push(String(dateFrom));
+      filterParams.push(String(dateFrom));
     }
     if (dateTo) {
       query += " AND e.date_sent <= ?";
-      params.push(String(dateTo));
+      filterParams.push(String(dateTo));
     }
 
-    // totals (same filters, no limit)
+    // Snapshot filter params before appending pagination, so the totals queries
+    // don't depend on params.slice arithmetic.
     const totalSql = `SELECT COUNT(*) FROM (${query})`;
-    const unreadSql = `SELECT COUNT(*) FROM (${query} AND is_read = 0)`;
+    const unreadSql = `SELECT COUNT(*) FROM (${query} AND e.is_read = 0)`;
 
-    query += " ORDER BY e.date_sent DESC LIMIT ? OFFSET ?";
-    params.push(Number(limit));
-    params.push(Number(offset));
+    const pagedQuery = query + " ORDER BY e.date_sent DESC LIMIT ? OFFSET ?";
+    const pagedParams = [...filterParams, Number(limit), Number(offset)];
 
-    const rows = _execRows(h.db, query, params);
+    const rows = _execRows(h.db, pagedQuery, pagedParams);
     const emails = rows.map((row) => ({
       id: String(row.id),
       uid: String(row.uid),
@@ -265,8 +392,8 @@ async function listEmailsFromCache({ dbPath, accountId, folder, unreadOnly, limi
       source: "cache_sync_db",
     }));
 
-    const total_in_folder = Number(_execScalar(h.db, totalSql, params.slice(0, -2)) || emails.length);
-    const unread_count = Number(_execScalar(h.db, unreadSql, params.slice(0, -2)) || emails.filter((e) => e.unread).length);
+    const total_in_folder = Number(_execScalar(h.db, totalSql, filterParams) || emails.length);
+    const unread_count = Number(_execScalar(h.db, unreadSql, filterParams) || emails.filter((e) => e.unread).length);
 
     return {
       success: true,
@@ -277,112 +404,45 @@ async function listEmailsFromCache({ dbPath, accountId, folder, unreadOnly, limi
       limit: Number(limit),
       from_cache: true,
     };
-  } catch {
+  } catch (e) {
+    if (process.env.MAILBOX_DEBUG) {
+      process.stderr.write(`sync_db cache read failed: ${e && e.message ? e.message : e}\n`);
+    }
     return null;
   } finally {
-    try {
-      h.close();
-    } catch {
-      // ignore
-    }
+    try { h.close(); } catch { /* ignore */ }
   }
 }
 
+// Standalone helpers — kept for backward compat. Each wraps a write session
+// so concurrent callers serialise on the file lock instead of clobbering.
 async function upsertAccount({ dbPath, id, email, provider }) {
-  const h = await openSyncDb(dbPath);
   try {
-    h.db.run(
-      "INSERT OR REPLACE INTO accounts (id, email, provider, updated_at) VALUES (?, ?, ?, CURRENT_TIMESTAMP)",
-      [String(id), String(email), String(provider)]
-    );
-    h.flush();
+    await withWriteSession(dbPath, (s) => s.upsertAccount({ id, email, provider }));
     return { success: true };
   } catch (e) {
     return { success: false, error: e && e.message ? e.message : "db error" };
-  } finally {
-    h.close();
   }
 }
 
 async function upsertFolder({ dbPath, accountId, name, displayName, messageCount, unreadCount, lastSyncIso }) {
-  const h = await openSyncDb(dbPath);
   try {
-    // Keep the Python semantics: do NOT use REPLACE because it breaks folder_id.
-    h.db.run(
-      `
-        INSERT INTO folders (account_id, name, display_name, message_count, unread_count, last_sync)
-        VALUES (?, ?, ?, ?, ?, ?)
-        ON CONFLICT(account_id, name) DO UPDATE SET
-          display_name = excluded.display_name,
-          message_count = excluded.message_count,
-          unread_count = excluded.unread_count,
-          last_sync = excluded.last_sync
-      `,
-      [
-        String(accountId),
-        String(name),
-        String(displayName || name),
-        Number(messageCount || 0),
-        Number(unreadCount || 0),
-        String(lastSyncIso || new Date().toISOString()),
-      ]
-    );
-    const folderId = _execScalar(
-      h.db,
-      "SELECT id FROM folders WHERE account_id = ? AND name = ?",
-      [String(accountId), String(name)]
-    );
-    h.flush();
-    return { success: true, folderId: Number(folderId) };
+    let folderId = 0;
+    await withWriteSession(dbPath, (s) => {
+      folderId = s.upsertFolder({ accountId, name, displayName, messageCount, unreadCount, lastSyncIso });
+    });
+    return { success: true, folderId };
   } catch (e) {
     return { success: false, error: e && e.message ? e.message : "db error" };
-  } finally {
-    h.close();
   }
 }
 
 async function upsertEmails({ dbPath, accountId, folderId, emails }) {
-  const h = await openSyncDb(dbPath);
   try {
-    const stmt = h.db.prepare(
-      `
-        INSERT OR REPLACE INTO emails (
-          account_id, folder_id, uid, message_id, subject, sender, sender_email, recipients,
-          date_sent, is_read, is_flagged, is_deleted, has_attachments, size_bytes, sync_status, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'synced', CURRENT_TIMESTAMP)
-      `
-    );
-    try {
-      for (const e of emails || []) {
-        const uid = String(e.uid || e.id || "").trim();
-        if (!uid) continue;
-        const isRead = e.unread ? 0 : 1;
-        stmt.run([
-          String(accountId),
-          Number(folderId),
-          uid,
-          String(e.message_id || ""),
-          String(e.subject || ""),
-          String(e.from || ""),
-          String(e.from || ""),
-          JSON.stringify({ to: e.to || "", cc: e.cc || "" }),
-          String(e.date || ""),
-          isRead,
-          0,
-          0,
-          e.has_attachments ? 1 : 0,
-          Number(e.size_bytes || e.size || 0),
-        ]);
-      }
-    } finally {
-      stmt.free();
-    }
-    h.flush();
+    await withWriteSession(dbPath, (s) => s.upsertEmails({ accountId, folderId, emails }));
     return { success: true };
   } catch (e) {
     return { success: false, error: e && e.message ? e.message : "db error" };
-  } finally {
-    h.close();
   }
 }
 
@@ -391,4 +451,5 @@ module.exports = {
   upsertAccount,
   upsertFolder,
   upsertEmails,
+  withWriteSession,
 };


### PR DESCRIPTION
## Summary

Two fix batches addressing the Critical and Important findings from the recent code review.

**Critical** (commit eee3299)
- SMTP/IMAP TLS hardening: requireTLS on non-implicit ports, rejectUnauthorized, TLSv1.2+ minimum. `MAILBOX_ALLOW_INSECURE_TLS=1` escape hatch.
- sync_db race fix: `withWriteSession` opens once, holds an exclusive file lock, atomic flush. Single session per `force()` pass — eliminates both within-account and cross-process lost-update races.
- `flagEmail`: real `flag_type` mapping (flagged/important/read/answered/junk/spam/...). Was always coercing to `\Flagged`.
- `replyEmail`: reply_all uses original `from + to + cc - self`, deduped. `References` builds proper chain. Locale-aware `Re:` prefix detection. `showEmail` exposes `in_reply_to` and `references`.

**Important** (commit 6942044)
- Body/attachment size caps (50/25/100 MiB) via `_safeParse` + downloadAttachments. Overridable via env.
- Test-branch path traversal in downloadAttachments fixed.
- `forwardEmail` re-fetches source and forwards real attachments (capped) in production. Previously dropped silently.
- `_findTrashFolder` relies on `\Trash` specialUse with clear error if missing — no silent fallback to a non-existent path.
- Cache read failures surface on stderr instead of silent live-IMAP fallback.
- Date sort uses `Date.parse` value, not lex string (cross-TZ aggregation).
- Env rename: `MAILBOX_TEST_MODE` -> `MAILBOX_INTERNAL_TEST_MODE` so user envs can't route account test-connection through the mock client.
- `--body-file` capped at 10 MiB.
- `_printTextNotImplemented` -> stderr (JSON pipe safety).
- SIGINT/SIGTERM cooperative shutdown for `sync watch`, `sync daemon`, `digest daemon`. In-flight pass drains before exit.
- `engines: node >=18.17` declared on `@mailbox/cli` and the published `@leeguoo/mailbox-cli`.

## Test plan

- [x] `pnpm -C packages/cli run test` (13/13 pass)
- [ ] Live IMAP `account test-connection` against Gmail/Outlook on port 587 — verify STARTTLS used and connection still works
- [ ] `mailbox sync force --account-id ...` from two shells concurrently — confirm the lock serializes and both writes survive
- [ ] `email reply --reply-all` against a thread with multiple recipients — verify To/Cc are correct
- [ ] `email flag --flag-type important` then `email flag --flag-type junk` — verify the flag actually changes
- [ ] `email forward` — verify attachments included
- [ ] `sync daemon` then ctrl-C — clean exit, no `*.lock` left behind