### PR TITLE
feat(cli): support outgoing attachments

### DIFF
--- a/docs/CLI_JSON_CONTRACT.md
+++ b/docs/CLI_JSON_CONTRACT.md
@@ -242,12 +242,81 @@ Batch or single:
 ```
 
 ### email send / reply / forward
+Default dry-run for send:
+```json
+{
+  "success": true,
+  "dry_run": true,
+  "would_send": {
+    "to": ["a@example.com"],
+    "cc": [],
+    "bcc": [],
+    "subject": "Hello",
+    "account_id": "acc_id",
+    "is_html": false,
+    "body_bytes": 42,
+    "body_preview": "message preview",
+    "attachment_count": 1,
+    "attachments": [
+      { "filename": "quote.txt", "path": "/path/to/quote.txt", "size_bytes": 1234 }
+    ]
+  },
+  "confirmation_required": true,
+  "confirmation_hint": "Re-run with --confirm to actually send"
+}
+```
+Default dry-run for reply:
+```json
+{
+  "success": true,
+  "dry_run": true,
+  "would_reply": {
+    "email_id": "123",
+    "folder": "INBOX",
+    "account_id": "acc_id",
+    "to": ["sender@example.com"],
+    "cc": [],
+    "subject": "Re: Hello",
+    "is_html": false,
+    "body_bytes": 42,
+    "body_preview": "message preview",
+    "attachment_count": 1,
+    "attachments": [
+      { "filename": "reply.txt", "path": "/path/to/reply.txt", "content_type": "text/plain" }
+    ]
+  },
+  "confirmation_required": true,
+  "confirmation_hint": "Re-run with --confirm to actually send"
+}
+```
+Default dry-run for forward:
+```json
+{
+  "success": true,
+  "dry_run": true,
+  "would_forward": {
+    "email_id": "123",
+    "folder": "INBOX",
+    "account_id": "acc_id",
+    "to": ["a@example.com"],
+    "subject": "Fwd: Hello",
+    "body_bytes": 42,
+    "body_preview": "message preview",
+    "include_original_attachments": true,
+    "original_attachment_count": 1
+  },
+  "confirmation_required": true,
+  "confirmation_hint": "Re-run with --confirm to actually send"
+}
+```
+Confirmed send/reply/forward:
 ```json
 {
   "success": true,
   "message": "Email sent successfully to 2 recipient(s)",
   "recipients": ["a@example.com", "b@example.com"],
-  "from": "user@example.com"
+  "from": "user@example.com",
+  "attachment_count": 1
 }
 ```
 On error: `{"success": false, "error": "...", "from": "user@example.com"}`.

--- a/packages/cli/src/core_client.js
+++ b/packages/cli/src/core_client.js
@@ -160,6 +160,19 @@ const MUTATING_FNS = new Set([
   "cleanup.apply",
 ]);
 
+function _hasOutgoingAttachments(args) {
+  const attachments = args && args.attachments;
+  if (!attachments) return false;
+  return Array.isArray(attachments) ? attachments.length > 0 : true;
+}
+
+function _shouldBypassDaemonForCall(fullName, args) {
+  if (fullName === "email.sendEmail") return _hasOutgoingAttachments(args);
+  if (fullName === "email.replyEmail") return Boolean(args && args.dry_run === true) || _hasOutgoingAttachments(args);
+  if (fullName === "email.forwardEmail") return Boolean(args && args.dry_run === true);
+  return false;
+}
+
 function _wrapNamespace(nsName, realObj) {
   const handler = {
     get(_, fname) {
@@ -173,7 +186,7 @@ function _wrapNamespace(nsName, realObj) {
         const args = callArgs[0]; // every core fn takes a single options object
         const isMutator = MUTATING_FNS.has(fullName);
         const isDryRun = isMutator && args && (args.dry_run === true);
-        const client = await _maybeConnect();
+        const client = _shouldBypassDaemonForCall(fullName, args) ? null : await _maybeConnect();
         if (client) {
           try {
             return await client.call(fullName, args);
@@ -215,4 +228,4 @@ function makeProxies() {
   };
 }
 
-module.exports = { makeProxies };
+module.exports = { makeProxies, _shouldBypassDaemonForCall };

--- a/packages/cli/src/main.js
+++ b/packages/cli/src/main.js
@@ -488,6 +488,53 @@ function _readBodyFile(bodyFilePath) {
   return fs.readFileSync(bodyFilePath, "utf8");
 }
 
+function _collectOption(value, previous) {
+  return [...(previous || []), value];
+}
+
+function _resolveLocalAttachments(values) {
+  const files = Array.isArray(values) ? values : [];
+  return files.map((raw) => {
+    const input = String(raw || "").trim();
+    if (!input) throw new Error("--attachment path cannot be empty");
+    const filePath = path.resolve(process.cwd(), input);
+    let st;
+    try {
+      st = fs.statSync(filePath);
+    } catch {
+      throw new Error(`--attachment not found: ${input}`);
+    }
+    if (!st.isFile()) throw new Error(`--attachment is not a file: ${input}`);
+    return {
+      filename: path.basename(filePath),
+      path: filePath,
+      size_bytes: st.size,
+    };
+  });
+}
+
+function _attachmentPreview(attachments) {
+  return (attachments || []).map((a) => ({
+    filename: a.filename,
+    path: a.path,
+    size_bytes: a.size_bytes,
+  }));
+}
+
+function _mailAttachments(attachments) {
+  return (attachments || []).map((a) => ({
+    filename: a.filename,
+    path: a.path,
+  }));
+}
+
+function _explicitOptionValue(cmd, opts, key) {
+  if (cmd && typeof cmd.getOptionValueSource === "function" && cmd.getOptionValueSource(key) === "cli") {
+    return opts[key];
+  }
+  return undefined;
+}
+
 // Cooperative shutdown for foreground daemons. SIGINT/SIGTERM flips the flag
 // and resolves any in-flight wait so the loop can finish its current pass
 // (e.g. mid-flush sqlite write) before exiting.
@@ -1157,6 +1204,7 @@ async function main(argv) {
     .option("--body-file <path>")
     .option("--cc <cc...>")
     .option("--bcc <bcc...>")
+    .option("--attachment <path>", "Attach a local file; repeat for multiple files", _collectOption, [])
     .option("--account-id <id>")
     .option("--is-html")
     .option("--confirm", "Actually send (default: dry-run)")
@@ -1178,6 +1226,13 @@ async function main(argv) {
           process.exit(rc);
         }
       }
+      let attachments;
+      try {
+        attachments = _resolveLocalAttachments(opts.attachment);
+      } catch (e) {
+        const rc = contract.invalidUsage({ message: e && e.message ? e.message : "Failed to read attachment", asJson, pretty });
+        process.exit(rc);
+      }
       const dryRun = Boolean(opts.dryRun) || !Boolean(opts.confirm);
       if (dryRun) {
         const result = {
@@ -1192,6 +1247,8 @@ async function main(argv) {
             is_html: Boolean(opts.isHtml),
             body_bytes: Buffer.byteLength(body, "utf8"),
             body_preview: body.slice(0, 200),
+            attachment_count: attachments.length,
+            attachments: _attachmentPreview(attachments),
           },
           confirmation_required: true,
           confirmation_hint: "Re-run with --confirm to actually send",
@@ -1207,6 +1264,7 @@ async function main(argv) {
         bcc: opts.bcc,
         account_id: opts.accountId || "",
         is_html: Boolean(opts.isHtml),
+        attachments: _mailAttachments(attachments),
       });
       const rc = contract.handleJsonOrText({ result, asJson, pretty, printText: () => _printTextNotImplemented("email send") });
       process.exit(rc);
@@ -1220,9 +1278,12 @@ async function main(argv) {
     .option("--body-file <path>")
     .option("--reply-all")
     .option("--folder <name>", "Folder", "INBOX")
+    .option("--attachment <path>", "Attach a local file; repeat for multiple files", _collectOption, [])
     .option("--account-id <id>")
     .option("--is-html")
-    .action(async (emailId, opts) => {
+    .option("--confirm", "Actually send (default: dry-run)")
+    .option("--dry-run")
+    .action(async (emailId, opts, cmd) => {
       const hasBody = typeof opts.body === "string" && opts.body.length;
       const hasBodyFile = Boolean(opts.bodyFile);
       if ((hasBody && hasBodyFile) || (!hasBody && !hasBodyFile)) {
@@ -1239,13 +1300,25 @@ async function main(argv) {
           process.exit(rc);
         }
       }
+      let attachments;
+      try {
+        attachments = _resolveLocalAttachments(opts.attachment);
+      } catch (e) {
+        const rc = contract.invalidUsage({ message: e && e.message ? e.message : "Failed to read attachment", asJson, pretty });
+        process.exit(rc);
+      }
+      const dryRun = Boolean(opts.dryRun) || !Boolean(opts.confirm);
+      const ref = _parseEmailRef(emailId);
+      const explicitFolder = _explicitOptionValue(cmd, opts, "folder");
       const result = await email.replyEmail({
-        email_id: emailId,
+        email_id: ref.id,
         body,
         reply_all: Boolean(opts.replyAll),
-        folder: opts.folder,
-        account_id: opts.accountId || "",
+        folder: explicitFolder || ref.folder || opts.folder,
+        account_id: opts.accountId || ref.account_id || "",
         is_html: Boolean(opts.isHtml),
+        attachments: _mailAttachments(attachments),
+        dry_run: dryRun,
       });
       const rc = contract.handleJsonOrText({ result, asJson, pretty, printText: () => _printTextNotImplemented("email reply") });
       process.exit(rc);
@@ -1260,14 +1333,20 @@ async function main(argv) {
     .option("--folder <name>", "Folder", "INBOX")
     .option("--no-attachments")
     .option("--account-id <id>")
-    .action(async (emailId, opts) => {
+    .option("--confirm", "Actually send (default: dry-run)")
+    .option("--dry-run")
+    .action(async (emailId, opts, cmd) => {
+      const dryRun = Boolean(opts.dryRun) || !Boolean(opts.confirm);
+      const ref = _parseEmailRef(emailId);
+      const explicitFolder = _explicitOptionValue(cmd, opts, "folder");
       const result = await email.forwardEmail({
-        email_id: emailId,
+        email_id: ref.id,
         to: opts.to,
         body: opts.body || "",
-        folder: opts.folder,
+        folder: explicitFolder || ref.folder || opts.folder,
         no_attachments: Boolean(opts.noAttachments),
-        account_id: opts.accountId || "",
+        account_id: opts.accountId || ref.account_id || "",
+        dry_run: dryRun,
       });
       const rc = contract.handleJsonOrText({ result, asJson, pretty, printText: () => _printTextNotImplemented("email forward") });
       process.exit(rc);

--- a/packages/cli/test/cli_contracts.contract.test.mjs
+++ b/packages/cli/test/cli_contracts.contract.test.mjs
@@ -218,6 +218,219 @@ describe("CLI JSON contract - MVP commands", () => {
     expect(payload).toHaveProperty("would_delete", 1);
   });
 
+  it("email send dry-run previews local attachments", async () => {
+    const root = tmpRoot("email_send_attachment_dry_run");
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.mkdirSync(root, { recursive: true });
+    const attachment = path.join(root, "quote.txt");
+    fs.writeFileSync(attachment, "attachment body", "utf8");
+
+    const env = testEnv(root);
+    writeAuthJson(env.MAILBOX_CONFIG_DIR, defaultAuth());
+
+    const r = await execa(
+      "node",
+      [
+        mailboxBin(),
+        "email",
+        "send",
+        "--to",
+        "person@example.com",
+        "--subject",
+        "Hello",
+        "--body",
+        "See attached",
+        "--attachment",
+        attachment,
+        "--json",
+      ],
+      {
+        reject: false,
+        env,
+      }
+    );
+
+    expect(r.exitCode).toBe(0);
+    const payload = JSON.parse(r.stdout);
+    expect(payload).toHaveProperty("success", true);
+    expect(payload).toHaveProperty("dry_run", true);
+    expect(payload.would_send).toHaveProperty("attachment_count", 1);
+    expect(payload.would_send.attachments[0]).toMatchObject({
+      filename: "quote.txt",
+      path: attachment,
+      size_bytes: Buffer.byteLength("attachment body"),
+    });
+  });
+
+  it("email send --confirm sends with local attachment metadata", async () => {
+    const root = tmpRoot("email_send_attachment_confirm");
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.mkdirSync(root, { recursive: true });
+    const attachment = path.join(root, "send-confirm.txt");
+    fs.writeFileSync(attachment, "send attachment", "utf8");
+
+    const env = testEnv(root);
+    writeAuthJson(env.MAILBOX_CONFIG_DIR, defaultAuth());
+
+    const r = await execa(
+      "node",
+      [
+        mailboxBin(),
+        "email",
+        "send",
+        "--to",
+        "person@example.com",
+        "--subject",
+        "Hello",
+        "--body",
+        "See attached",
+        "--attachment",
+        attachment,
+        "--account-id",
+        "mock_acc",
+        "--confirm",
+        "--json",
+      ],
+      {
+        reject: false,
+        env,
+      }
+    );
+
+    expect(r.exitCode).toBe(0);
+    const payload = JSON.parse(r.stdout);
+    expect(payload).toMatchObject({
+      success: true,
+      attachment_count: 1,
+    });
+  });
+
+  it("email reply dry-run previews recipients and local attachments", async () => {
+    const root = tmpRoot("email_reply_attachment_dry_run");
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.mkdirSync(root, { recursive: true });
+    const attachment = path.join(root, "reply.txt");
+    fs.writeFileSync(attachment, "reply attachment", "utf8");
+
+    const env = testEnv(root);
+    writeAuthJson(env.MAILBOX_CONFIG_DIR, defaultAuth());
+
+    const r = await execa(
+      "node",
+      [
+        mailboxBin(),
+        "email",
+        "reply",
+        "mock_acc:INBOX:101",
+        "--body",
+        "Reply body",
+        "--attachment",
+        attachment,
+        "--json",
+      ],
+      {
+        reject: false,
+        env,
+      }
+    );
+
+    expect(r.exitCode).toBe(0);
+    const payload = JSON.parse(r.stdout);
+    expect(payload).toHaveProperty("success", true);
+    expect(payload).toHaveProperty("dry_run", true);
+    expect(payload.would_reply).toMatchObject({
+      email_id: "101",
+      subject: "Re: Hello",
+      attachment_count: 1,
+    });
+    expect(payload.would_reply.to).toContain("sender@example.com");
+    expect(payload.would_reply.attachments[0]).toMatchObject({
+      filename: "reply.txt",
+      path: attachment,
+    });
+  });
+
+  it("email reply --confirm sends with local attachment metadata", async () => {
+    const root = tmpRoot("email_reply_attachment_confirm");
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.mkdirSync(root, { recursive: true });
+    const attachment = path.join(root, "reply-confirm.txt");
+    fs.writeFileSync(attachment, "reply attachment", "utf8");
+
+    const env = testEnv(root);
+    writeAuthJson(env.MAILBOX_CONFIG_DIR, defaultAuth());
+
+    const r = await execa(
+      "node",
+      [
+        mailboxBin(),
+        "email",
+        "reply",
+        "101",
+        "--body",
+        "Reply body",
+        "--folder",
+        "INBOX",
+        "--account-id",
+        "mock_acc",
+        "--attachment",
+        attachment,
+        "--confirm",
+        "--json",
+      ],
+      {
+        reject: false,
+        env,
+      }
+    );
+
+    expect(r.exitCode).toBe(0);
+    const payload = JSON.parse(r.stdout);
+    expect(payload).toMatchObject({
+      success: true,
+      attachment_count: 1,
+    });
+  });
+
+  it("email forward defaults to dry-run until --confirm", async () => {
+    const root = tmpRoot("email_forward_dry_run");
+    fs.rmSync(root, { recursive: true, force: true });
+
+    const env = testEnv(root);
+    writeAuthJson(env.MAILBOX_CONFIG_DIR, defaultAuth());
+
+    const r = await execa(
+      "node",
+      [
+        mailboxBin(),
+        "email",
+        "forward",
+        "mock_acc:INBOX:102",
+        "--to",
+        "person@example.com",
+        "--body",
+        "FYI",
+        "--json",
+      ],
+      {
+        reject: false,
+        env,
+      }
+    );
+
+    expect(r.exitCode).toBe(0);
+    const payload = JSON.parse(r.stdout);
+    expect(payload).toHaveProperty("success", true);
+    expect(payload).toHaveProperty("dry_run", true);
+    expect(payload.would_forward).toMatchObject({
+      email_id: "102",
+      subject: "Fwd: Unread Note",
+      include_original_attachments: true,
+      original_attachment_count: 1,
+    });
+    expect(payload).toHaveProperty("confirmation_required", true);
+  });
+
   it("sync status returns scheduler fields", async () => {
     const root = tmpRoot("sync_status");
     fs.rmSync(root, { recursive: true, force: true });

--- a/packages/cli/test/codex_review_fixes.contract.test.mjs
+++ b/packages/cli/test/codex_review_fixes.contract.test.mjs
@@ -1,10 +1,13 @@
 // Regression tests for the 4 issues codex review surfaced and we just fixed.
+import { createRequire } from "node:module";
 import { describe, expect, it } from "vitest";
 import { execa } from "execa";
 import path from "node:path";
 import fs from "node:fs";
 
 import { defaultAuth, testEnv, writeAuthJson } from "./_helpers.mjs";
+
+const require = createRequire(import.meta.url);
 
 function tmpRoot(name) {
   return path.join(import.meta.dirname, ".tmp", name);
@@ -14,6 +17,87 @@ function mailboxBin() {
 }
 
 describe("Codex review fixes (regression)", () => {
+  it("outgoing attachment and new dry-run semantics bypass stale daemons", async () => {
+    const { _shouldBypassDaemonForCall } = require("../src/core_client.js");
+
+    expect(_shouldBypassDaemonForCall("email.sendEmail", {
+      attachments: [{ path: "/tmp/a.txt" }],
+    })).toBe(true);
+    expect(_shouldBypassDaemonForCall("email.sendEmail", {
+      attachments: [],
+    })).toBe(false);
+    expect(_shouldBypassDaemonForCall("email.replyEmail", {
+      dry_run: true,
+    })).toBe(true);
+    expect(_shouldBypassDaemonForCall("email.replyEmail", {
+      attachments: [{ path: "/tmp/a.txt" }],
+    })).toBe(true);
+    expect(_shouldBypassDaemonForCall("email.forwardEmail", {
+      dry_run: true,
+    })).toBe(true);
+    expect(_shouldBypassDaemonForCall("email.forwardEmail", {
+      dry_run: false,
+    })).toBe(false);
+  });
+
+  it("email reply lets explicit --folder override the gid folder", async () => {
+    const root = tmpRoot("reply_folder_override");
+    fs.rmSync(root, { recursive: true, force: true });
+    const env = testEnv(root);
+    writeAuthJson(env.MAILBOX_CONFIG_DIR, defaultAuth());
+
+    const r = await execa(
+      "node",
+      [mailboxBin(), "email", "reply", "mock_acc:Trash:101", "--folder", "INBOX", "--body", "Reply body", "--json"],
+      { reject: false, env }
+    );
+
+    expect(r.exitCode).toBe(0);
+    const payload = JSON.parse(r.stdout);
+    expect(payload).toHaveProperty("success", true);
+    expect(payload).toHaveProperty("dry_run", true);
+    expect(payload.would_reply).toMatchObject({
+      email_id: "101",
+      folder: "INBOX",
+      subject: "Re: Hello",
+    });
+  });
+
+  it("email forward lets explicit --folder override the gid folder", async () => {
+    const root = tmpRoot("forward_folder_override");
+    fs.rmSync(root, { recursive: true, force: true });
+    const env = testEnv(root);
+    writeAuthJson(env.MAILBOX_CONFIG_DIR, defaultAuth());
+
+    const r = await execa(
+      "node",
+      [
+        mailboxBin(),
+        "email",
+        "forward",
+        "mock_acc:Trash:102",
+        "--folder",
+        "INBOX",
+        "--to",
+        "person@example.com",
+        "--body",
+        "FYI",
+        "--json",
+      ],
+      { reject: false, env }
+    );
+
+    expect(r.exitCode).toBe(0);
+    const payload = JSON.parse(r.stdout);
+    expect(payload).toHaveProperty("success", true);
+    expect(payload).toHaveProperty("dry_run", true);
+    expect(payload.would_forward).toMatchObject({
+      email_id: "102",
+      folder: "INBOX",
+      subject: "Fwd: Unread Note",
+    });
+  });
+
   it("BUG-1a: email flag without --confirm is dry-run, doesn't mutate", async () => {
     const root = tmpRoot("flag_dry_run");
     fs.rmSync(root, { recursive: true, force: true });

--- a/packages/core/src/services/email.js
+++ b/packages/core/src/services/email.js
@@ -1507,7 +1507,20 @@ async function deleteEmails({ email_ids, folder = "INBOX", permanent = false, tr
   });
 }
 
-async function sendEmail({ to, subject, body, cc, bcc, account_id = "", is_html = false } = {}) {
+function _outgoingAttachments(attachments) {
+  if (!attachments) return [];
+  return Array.isArray(attachments) ? attachments.filter(Boolean) : [attachments];
+}
+
+function _outgoingAttachmentPreview(attachments) {
+  return _outgoingAttachments(attachments).map((a) => ({
+    filename: a.filename || (a.path ? path.basename(String(a.path)) : "attachment"),
+    path: a.path || undefined,
+    content_type: a.contentType || undefined,
+  }));
+}
+
+async function sendEmail({ to, subject, body, cc, bcc, account_id = "", is_html = false, attachments = [] } = {}) {
   const tos = Array.isArray(to) ? to : [to];
   const recipients = tos.map((x) => String(x)).filter((x) => x.trim());
   if (!recipients.length) return { success: false, error: "Missing --to" };
@@ -1518,6 +1531,7 @@ async function sendEmail({ to, subject, body, cc, bcc, account_id = "", is_html 
   if (!acc.success) return acc;
 
   try {
+    const outgoingAttachments = _outgoingAttachments(attachments);
     const r = await sendMail({
       account: acc.account,
       to: recipients.join(", "),
@@ -1526,6 +1540,7 @@ async function sendEmail({ to, subject, body, cc, bcc, account_id = "", is_html 
       subject: subj,
       text: is_html ? "" : String(body || ""),
       html: is_html ? String(body || "") : "",
+      attachments: outgoingAttachments,
     });
 
     if (!r.success) return r;
@@ -1534,6 +1549,7 @@ async function sendEmail({ to, subject, body, cc, bcc, account_id = "", is_html 
       message: `Email sent successfully to ${recipients.length} recipient(s)`,
       recipients,
       from: acc.account.email,
+      attachment_count: outgoingAttachments.length,
     };
   } catch (e) {
     return { success: false, error: e && e.message ? e.message : "send failed", from: acc.account.email };
@@ -1579,11 +1595,12 @@ function _buildReferences(detail) {
   return refs.join(" ").trim();
 }
 
-async function replyEmail({ email_id, body, reply_all = false, folder = "INBOX", account_id = "", is_html = false } = {}) {
+async function replyEmail({ email_id, body, reply_all = false, folder = "INBOX", account_id = "", is_html = false, attachments = [], dry_run = false } = {}) {
   const detail = await showEmail({ email_id, folder, account_id });
   if (!detail.success) return detail;
   const acc = accounts.getAccountByIdOrEmail(account_id);
   if (!acc.success) return acc;
+  const outgoingAttachments = _outgoingAttachments(attachments);
 
   const fromAddr = detail.from || "";
   let toList = [fromAddr].filter(Boolean);
@@ -1605,6 +1622,28 @@ async function replyEmail({ email_id, body, reply_all = false, folder = "INBOX",
   const refs = _buildReferences(detail);
   if (refs) headers.References = refs;
 
+  if (dry_run) {
+    return {
+      success: true,
+      dry_run: true,
+      would_reply: {
+        email_id: String(email_id || ""),
+        folder,
+        account_id: acc.account.id,
+        to: toList,
+        cc: ccList,
+        subject,
+        is_html: Boolean(is_html),
+        body_bytes: Buffer.byteLength(String(body || ""), "utf8"),
+        body_preview: String(body || "").slice(0, 200),
+        attachment_count: outgoingAttachments.length,
+        attachments: _outgoingAttachmentPreview(outgoingAttachments),
+      },
+      confirmation_required: true,
+      confirmation_hint: "Re-run with --confirm to actually send",
+    };
+  }
+
   try {
     await sendMail({
       account: acc.account,
@@ -1613,6 +1652,7 @@ async function replyEmail({ email_id, body, reply_all = false, folder = "INBOX",
       subject,
       text: is_html ? "" : String(body || ""),
       html: is_html ? String(body || "") : "",
+      attachments: outgoingAttachments,
       headers,
     });
     return {
@@ -1621,13 +1661,14 @@ async function replyEmail({ email_id, body, reply_all = false, folder = "INBOX",
       recipients: toList,
       cc: ccList,
       from: acc.account.email,
+      attachment_count: outgoingAttachments.length,
     };
   } catch (e) {
     return { success: false, error: e && e.message ? e.message : "reply failed", from: acc.account.email };
   }
 }
 
-async function forwardEmail({ email_id, to, body = "", folder = "INBOX", no_attachments = false, account_id = "" } = {}) {
+async function forwardEmail({ email_id, to, body = "", folder = "INBOX", no_attachments = false, account_id = "", dry_run = false } = {}) {
   const detail = await showEmail({ email_id, folder, account_id });
   if (!detail.success) return detail;
   const acc = accounts.getAccountByIdOrEmail(account_id);
@@ -1635,6 +1676,28 @@ async function forwardEmail({ email_id, to, body = "", folder = "INBOX", no_atta
 
   const recipients = (Array.isArray(to) ? to : [to]).map((x) => String(x)).filter((x) => x.trim());
   if (!recipients.length) return { success: false, error: "Missing --to" };
+  const subject = `Fwd: ${detail.subject || ""}`;
+
+  if (dry_run) {
+    const originalAttachmentCount = no_attachments ? 0 : (detail.real_attachment_count || detail.attachment_count || 0);
+    return {
+      success: true,
+      dry_run: true,
+      would_forward: {
+        email_id: String(email_id || ""),
+        folder,
+        account_id: acc.account.id,
+        to: recipients,
+        subject,
+        body_bytes: Buffer.byteLength(String(body || ""), "utf8"),
+        body_preview: String(body || "").slice(0, 200),
+        include_original_attachments: !no_attachments,
+        original_attachment_count: originalAttachmentCount,
+      },
+      confirmation_required: true,
+      confirmation_hint: "Re-run with --confirm to actually send",
+    };
+  }
 
   let attachments = [];
   if (!no_attachments && detail.attachment_count) {
@@ -1678,7 +1741,7 @@ async function forwardEmail({ email_id, to, body = "", folder = "INBOX", no_atta
     await sendMail({
       account: acc.account,
       to: recipients.join(", "),
-      subject: `Fwd: ${detail.subject || ""}`,
+      subject,
       text: String(body || ""),
       attachments,
     });
@@ -1687,6 +1750,7 @@ async function forwardEmail({ email_id, to, body = "", folder = "INBOX", no_atta
       message: `Email sent successfully to ${recipients.length} recipient(s)`,
       recipients,
       from: acc.account.email,
+      attachment_count: attachments.length,
     };
   } catch (e) {
     return { success: false, error: e && e.message ? e.message : "forward failed", from: acc.account.email };


### PR DESCRIPTION
## Summary
- add repeatable `--attachment <path>` support to `mailbox email send` and `mailbox email reply`
- add dry-run previews for `reply` and `forward`, requiring `--confirm` before sending
- make `reply` and `forward` accept 3-part gids by resolving account/folder/uid before calling core
- document the new send/reply/forward JSON contract shapes

## Why
Agents can already download attachments, but outgoing attachment support was only available at the low-level SMTP layer. The CLI and core email service did not expose it for send/reply. Reply and forward also sent immediately, unlike other mutating commands that default to dry-run previews.

## Impact
- `email send --attachment file --confirm --json` sends local files through Nodemailer attachments.
- `email reply --attachment file --confirm --json` sends local files while preserving threading headers.
- `email reply` and `email forward` now default to safe dry-run previews unless `--confirm` is passed.
- `email forward` still preserves original attachments by default and does not add new local attachment support in this PR.

## Validation
- `MAILBOX_NO_DAEMON=1 corepack pnpm -r --if-present test`
- `git diff --check`
- Manual live QQ IMAP/SMTP smoke test for send/reply attachments and reply threading.